### PR TITLE
Updated tests of note and user services to test the code inside promises

### DIFF
--- a/notes_app/client/app/notes/notes_service.js
+++ b/notes_app/client/app/notes/notes_service.js
@@ -15,6 +15,7 @@
     }
     return {
       'data': data,
+      'api_path': api_path,
       'list': function(limit, offset) {
         return $http.get(api_path, {
           'params': {

--- a/notes_app/client/app/users/user_service.js
+++ b/notes_app/client/app/users/user_service.js
@@ -7,6 +7,7 @@
         user = {'logged_in': false, 'data': null};
     return {
       'user': user,
+      'api_path': api_path,
       'list': function() {
         return $http.get(api_path).then(function successHandler(response) {
           return response.data;
@@ -19,14 +20,14 @@
         return $http.put(api_path + id + '/', data).then(function(response){
           return;
         }).catch(function(error){
-          console.log(error);
+          $log.error(error);
         });
       },
       'delete': function(id) {
         return $http.delete(api_path + id + '/').then(function(response){
           return;
         }).catch(function(error){
-          console.log(error);
+          $log.error(error);
         });
       },
       'register': function(username, password) {


### PR DESCRIPTION
- tests for creating and updating users
- logging in create and update methods of user service through Angular's $log service, not console.log
- full coverage of note and user services
- replaced $httpBackend when checks with more strict expect checks
